### PR TITLE
Fix an thread-unsafe issue for this version of Restkit.

### DIFF
--- a/Code/CoreData/NSManagedObjectContext+RKAdditions.m
+++ b/Code/CoreData/NSManagedObjectContext+RKAdditions.m
@@ -52,8 +52,11 @@
          4. Save the child context to the parent context (the main one) which will work,
          5. Save the main context - a NSObjectInaccessibleException will occur and Core Data will either crash your app or lock it up (a semaphore is not correctly released on the first error so the next fetch request will block forever.
          */
-        [contextToSave obtainPermanentIDsForObjects:[[contextToSave insertedObjects] allObjects] error:&localError];
-        if (localError) {
+        __block BOOL obtained;
+        [contextToSave performBlockAndWait:^{
+            obtained = [contextToSave obtainPermanentIDsForObjects:[[contextToSave insertedObjects] allObjects] error:&localError];
+        }];
+        if (!obtained) {
             if (error) *error = localError;
             return NO;
         }

--- a/Code/CoreData/RKManagedObjectStore.m
+++ b/Code/CoreData/RKManagedObjectStore.m
@@ -333,8 +333,12 @@ static char RKManagedObjectContextChangeMergingObserverAssociationKey;
 
 - (BOOL)resetPersistentStores:(NSError **)error
 {
-    [self.mainQueueManagedObjectContext reset];
-    [self.persistentStoreManagedObjectContext reset];
+    [self.mainQueueManagedObjectContext performBlockAndWait:^{
+        [self.mainQueueManagedObjectContext reset];
+    }];
+    [self.persistentStoreManagedObjectContext performBlockAndWait:^{
+        [self.persistentStoreManagedObjectContext reset];
+    }];
     
     NSError *localError;
     for (NSPersistentStore *persistentStore in self.persistentStoreCoordinator.persistentStores) {

--- a/Code/Network/RKManagedObjectRequestOperation.m
+++ b/Code/Network/RKManagedObjectRequestOperation.m
@@ -824,7 +824,11 @@ BOOL RKDoesArrayOfResponseDescriptorsContainOnlyEntityMappings(NSArray *response
 
 - (BOOL)saveContext:(NSError **)error
 {
-    if ([self.privateContext hasChanges]) {
+    __block BOOL hasChanges;
+    [self.privateContext performBlockAndWait:^{
+        hasChanges = [self.privateContext hasChanges];
+    }];
+    if (hasChanges) {
         return [self saveContext:self.privateContext error:error];
     } else if ([self.targetObject isKindOfClass:[NSManagedObject class]]) {
         NSManagedObjectContext *context = [(NSManagedObject *)self.targetObject managedObjectContext];


### PR DESCRIPTION
Restkit version 0.20.3 we are using is a version from year 2013, it also includes some therad-unsafe methods when incorporating with CoreData.

This PR is used to fix the thread-unsafe methods in Restkit 0.20.3 by using CoreData block-based API.